### PR TITLE
Allow inclusion of moment library to parse date

### DIFF
--- a/js/sortable.js
+++ b/js/sortable.js
@@ -1,5 +1,5 @@
 (function() {
-  var SELECTOR, addEventListener, clickEvents, numberRegExp, sortable, touchDevice, trimRegExp;
+  var SELECTOR, addEventListener, clickEvents, numberRegExp, sortable, touchDevice, trimRegExp, hasMoment, momentDateFormat;
 
   SELECTOR = 'table[data-sortable]';
 
@@ -10,6 +10,10 @@
   clickEvents = ['click'];
 
   touchDevice = 'ontouchstart' in document.documentElement;
+
+  hasMoment = (typeof window.moment === 'function');
+
+  momentDateFormat = 'YYYY-MM-DD HH:mm:ss';
 
   if (touchDevice) {
     clickEvents.push('touchstart');
@@ -31,6 +35,9 @@
       }
       if (options.selector == null) {
         options.selector = SELECTOR;
+      }
+      if (options.momentDateFormat !== null) {
+        momentDateFormat = options.momentDateFormat;
       }
       tables = document.querySelectorAll(options.selector);
       _results = [];
@@ -204,10 +211,19 @@
       defaultSortDirection: 'ascending',
       reverse: true,
       match: function(a) {
-        return !isNaN(Date.parse(a));
+        if (hasMoment) {
+          return moment(a, momentDateFormat).isValid();
+        } else {
+          return !isNaN(Date.parse(a));
+        }
       },
       comparator: function(a) {
-        return Date.parse(a) || 0;
+        if (hasMoment) {
+          var d = moment(a, momentDateFormat);
+          return d.isValid() ? d.toDate() : 0;
+        } else {
+          return Date.parse(a) || 0;
+        }
       }
     }, {
       name: 'alpha',


### PR DESCRIPTION
This addition allows users who have the great momentjs library loaded to parse date-cells with locale string. The locale String must be set via Sortable.init():

```
Sortable.init( { 'momentDateFormat' : 'DD.MM.YYYY hh:mm' });
```

The parser will then be set globally. Default format is currently 'YYYY-MM-DD HH:mm:ss'. 
This feature will also help user with issue #41 to solve sorting-problems.
A nice improvement would be to allow the format to be set per-column as a setting in the table-headers. I didn't see, how this could be incorporated.
